### PR TITLE
Linuxify Cakefile, IEify test suite

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -12,9 +12,9 @@ execCmds = (cmds) ->
 
 task 'build', 'Build the library', ->
     execCmds [
-        'pushd src/sel',
+        'cd src/sel',
         'cat _pre.coffee util.coffee find.coffee pseudos.coffee parser.coffee eval.coffee select.coffee _post.coffee > sel.coffee',
-        'popd',
+        'cd ../..',
         'coffee --compile --bare --output lib src/sel/sel.coffee',
         'coffee --compile --bare --output lib src/extras/ender.coffee',
     ]
@@ -29,10 +29,10 @@ task 'test', 'Build the test suite', ->
         'ln -sf ../src/test/vows.css test',
 
         'npm install --dev',
-        'ln -sfh ender-vows node_modules/vows',
+        'ln -sfn ender-vows node_modules/vows',
 
-        'pushd test',
-        'ln -sfh ../node_modules node_modules',
+        'cd test',
+        'ln -sfn ../node_modules node_modules',
         'node_modules/.bin/ender build ender-vows ..',
-        'popd test',
+        'cd ..',
     ]

--- a/src/test/index.html
+++ b/src/test/index.html
@@ -20,4 +20,6 @@
 </head>
 <body>
     <!-- Test Results -->
-	<pre id="vows-results"></pre>
+    <pre id="vows-results"></pre>
+</body>
+</html>

--- a/src/test/selectors-test.coffee
+++ b/src/test/selectors-test.coffee
@@ -68,9 +68,12 @@ testTopic = (lib, success) ->
     el.style.height = 0
     el.style.display = 'none'
     el.style.visibility = 'hidden'
-    el.onload = () ->
+    onload = ->
         success(lib, el.contentDocument)
-    
+    if window.addEventListener
+        el.addEventListener 'load', onload
+    else
+        el.attachEvent 'onload', onload
     document.body.appendChild(el)
     return
     

--- a/src/test/vows.css
+++ b/src/test/vows.css
@@ -12,7 +12,7 @@ body {
 }
 
 #vows-results div {
-    display: inline;
+    /*display: inline;*/
 }
 
 .success {


### PR DESCRIPTION
I've only tested these Cakefile changes on Linux, I'm hoping they'll work on your platform which I'm assuming is a Mac (or perhaps it's Windows and the `../..` will mess things up?).
The `display:inline` was causing the test items to display all in a single row on IE, seems to work fine on all browsers if it's just left as block.
Test support in IE6 & 7 needs some work as per PM and my lack of familiarity with Vows is probably going to be an impediment to figuring out what's going on. Hopefully you find some time to look at this, I'll keep an eye on any change you make.
